### PR TITLE
Add Build Tools

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,0 +1,30 @@
+package-as: FactionFriend_Reborn
+
+externals:
+    Libs/AceAddon-3.0:
+        url: https://repos.wowace.com/wow/ace3/trunk/AceAddon-3.0
+        tag: latest
+    Libs/AceConfig-3.0:
+        url: https://repos.wowace.com/wow/ace3/trunk/AceConfig-3.0
+        tag: latest
+    Libs/AceDB-3.0:
+        url: https://repos.wowace.com/wow/ace3/trunk/AceDB-3.0
+        tag: latest
+    Libs/AceDBOptions-3.0:
+        url: https://repos.wowace.com/wow/ace3/trunk/AceDBOptions-3.0
+        tag: latest
+    Libs/AceGUI-3.0:
+        url: https://repos.wowace.com/wow/ace3/trunk/AceGUI-3.0
+        tag: latest
+    Libs/CallbackHandler-1.0:
+        url: https://repos.wowace.com/wow/callbackhandler/trunk/CallbackHandler-1.0
+        tag: latest
+    Libs/LibStub:
+        url: https://repos.wowace.com/wow/libstub/trunk
+        tag: latest
+
+ignore:
+    - Libs/
+    - readme.txt
+    - readme-API.txt
+    - .travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: minimal
+
+script:
+  - curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -g 1.13.2
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/FactionFriend.toc
+++ b/FactionFriend.toc
@@ -8,6 +8,7 @@
 ## SavedVariables: GFW_FactionFriend_DB
 ## SavedVariablesPerCharacter: FFF_RecentFactions, FFF_LastTabardID
 ## X-LoadOn-Hooks: MainMenuBar_UpdateExperienceBars
+## X-Curse-Project-ID: 345969
 
 GFWUtils.lua
 GFWTable.lua

--- a/GFW_FactionFriend.toc
+++ b/GFW_FactionFriend.toc
@@ -1,9 +1,8 @@
 ## Interface: 11302
-## Version: 8.0.1-classic
-## Author: Gazmik Fizzwidget
-## X-Website: http://fizzwidget.com/factionfriend
-## X-Appcast: http://fizzwidget.com/notes/factionfriend/feed
-## Title: Fizzwidget FactionFriend
+## Version: 0.1
+## Author: Dragonwolf Dreamwalker
+## X-Website: https://dreamwalker-collective.github.io/
+## Title: FactionFriend Reborn
 ## Notes: Switches WoW's builtin reputation watch bar automatically and helps keep track of faction turnin items.
 ## X-Category: Interface Enhancements
 ## SavedVariables: GFW_FactionFriend_DB

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Founded by a Druidic Ambassador, the Dreamwalker Collective knows the tremendous
 
 As he so aptly put it:
 
-> It's amazing the lengths some will go to to win friends. Gaining the trust of furblog tribes, mushroom men, frost giants, and other organizations of demi-goblinoid races can be a lot of work, and it can be easy sometimes to lose track of one's progress. That's where Fizzwidget Industries comes in! Our newest gadget not only helps you keep tabs on whose respect you're earning, but also how much more you could earn by turning in certain items you're carrying.
+> It's amazing the lengths some will go to to win friends. Gaining the trust of furbolg tribes, mushroom men, frost giants, and other organizations of demi-goblinoid races can be a lot of work, and it can be easy sometimes to lose track of one's progress. That's where Fizzwidget Industries comes in! Our newest gadget not only helps you keep tabs on whose respect you're earning, but also how much more you could earn by turning in certain items you're carrying.
 
 Is it any wonder why we couldn't just let it be relegated to a corner of his workshop, while he is off to someplace unknown, possibly never to return?
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# FactionFriend Reborn
+
+Founded by a Druidic Ambassador, the Dreamwalker Collective knows the tremendous value of keeping track of where one stands with the numerous factions of Azeroth and beyond. Even from our earliest days, we were not long without [FactionFriend](http://www.fizzwidget.com/factionfriend), the faction managing gadget created by the wonderful little goblin, [Gazmik Fizzwidget](http://www.fizzwidget.com).
+
+As he so aptly put it:
+
+> It's amazing the lengths some will go to to win friends. Gaining the trust of furblog tribes, mushroom men, frost giants, and other organizations of demi-goblinoid races can be a lot of work, and it can be easy sometimes to lose track of one's progress. That's where Fizzwidget Industries comes in! Our newest gadget not only helps you keep tabs on whose respect you're earning, but also how much more you could earn by turning in certain items you're carrying.
+
+Is it any wonder why we couldn't just let it be relegated to a corner of his workshop, while he is off to someplace unknown, possibly never to return?
+
+We've picked up the mantle in his stead, keeping one of our most favorite gadgets in working order, and we hope that if -- _when_ -- he returns, he'll appreciate the care we've taken of it in his absence.
+
+# What About The Classic-Retail Split?
+
+We've started our journey anew in Old Azeroth, and that is where our focus is going to be for the time being. However, we are taking care to preserve the original legacy of FactionFriend, so that we can polish it up for our friends fighting in the Battle for Azeroth. Earthmother knows, diplomacy hasn't gotten any less complicated in recent years!
+
+Because of recent changes to the addon system, we've needed to make some significant changes to get it working properly. We're hoping that the changes and improvements we're making in the process of porting it to Classic will fix some of the issues that have stumped us in previous attempts to fix it for Retail.


### PR DESCRIPTION
Adding build tools will allow us to release for both Classic and Retail from the same base of code, so that we don't have to maintain completely separate repositories.