### PR TITLE
Centralize the showConfig bug workaround, so both slash commands and …

### DIFF
--- a/FactionFriend.lua
+++ b/FactionFriend.lua
@@ -133,9 +133,6 @@ function FFF_OnLoad(self)
 	SLASH_FFF2 = "/ff";
 	SlashCmdList["FFF"] = function(msg)
 		GFW_FactionFriend:ShowConfig();
-		-- Call a second time to handle the bug of slash
-		-- commands not going to the actual options panel
-		GFW_FactionFriend:ShowConfig();
 	end
 		
 end

--- a/Initialize.lua
+++ b/Initialize.lua
@@ -240,4 +240,6 @@ end
 
 function GFW_FactionFriend:ShowConfig()
     InterfaceOptionsFrame_OpenToCategory(self.optionsFrames.general)
+    -- Fix for bug where calling it the first time doesn't actually open to the addon options
+    InterfaceOptionsFrame_OpenToCategory(self.optionsFrames.general)
 end


### PR DESCRIPTION
…menu items to show the config work as expected.